### PR TITLE
Add support for PerMonitorV2 DPI awareness

### DIFF
--- a/application.manifest
+++ b/application.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <assemblyIdentity
-        version="0.2.0.0"
+        version="0.3.0.0"
         processorArchitecture="*"
         name="Andrew.R.Schmidt.LightWeightMusicStreamer"
         type="win32"
@@ -21,7 +21,7 @@
     </dependency>
     <asmv3:application>
         <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
-          <dpiAwareness>PerMonitor</dpiAwareness>
+          <dpiAwareness>PerMonitorV2, PerMonitor</dpiAwareness>
         </asmv3:windowsSettings>
         <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings"> 
             <activeCodePage>UTF-8</activeCodePage> 

--- a/main.cpp
+++ b/main.cpp
@@ -57,7 +57,7 @@ struct StreamingSource
     const std::wstring_view m_uri;
 };
 
-const std::array g_musicSources = 
+constexpr std::array g_musicSources
 {
     StreamingSource{ L"Deepinradio", L"http://s3.viastreaming.net:8525"sv },
     StreamingSource{ L"KCSM", L"http://ice5.securenetsystems.net/KCSM"sv },
@@ -112,7 +112,11 @@ void StreamingPlayerDialog::OnInitialize()
         }
         check_bool(SendMessage(comboHwnd, CB_SETITEMDATA, index, reinterpret_cast<LPARAM>(&source)) != CB_ERR);
     }
-    SendMessage(comboHwnd, CB_SETCURSEL, 0, 0);
+
+    if constexpr (g_musicSources.size() > 0)
+    {
+        SendMessage(comboHwnd, CB_SETCURSEL, 0, 0);
+    }
 }
 
 void StreamingPlayerDialog::OpenAndPlayStreamingSource()
@@ -120,6 +124,7 @@ void StreamingPlayerDialog::OpenAndPlayStreamingSource()
     Uri uri{ GetSource().m_uri };
     auto streamingSource{ Windows::Media::Core::MediaSource::CreateFromUri(std::move(uri)) };
     m_mediaPlayer = Windows::Media::Playback::MediaPlayer{};
+    m_mediaPlayer.CommandManager().IsEnabled(false);
 
     auto async = streamingSource.OpenAsync();
     async.Completed([hDlg = m_hDlg, player = m_mediaPlayer, source = std::move(streamingSource)](const IAsyncAction& async, const AsyncStatus status)


### PR DESCRIPTION
This enables the dialog box to automatically rescale when moved between monitors with different DPI. The Media Command Manager is also disabled.

Other very minor C++ tweaks go along for the ride